### PR TITLE
Add NoInvalidReferenceToPricingPlansInVehicleStatus rule

### DIFF
--- a/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleStatus.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleStatus.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  *
+ *  *
+ *  *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  *  * You may not use this work except in compliance with the Licence.
+ *  *  * You may obtain a copy of the Licence at:
+ *  *  *
+ *  *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the Licence for the specific language governing permissions and
+ *  *  * limitations under the Licence.
+ *  *
+ *
+ */
+
+package org.entur.gbfs.validation.validator.rules;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Map;
+
+/**
+ * A vehicle's pricing_plan_id must exist in the system's system_pricing_plan file
+ */
+public class NoInvalidReferenceToPricingPlansInVehicleStatus implements CustomRuleSchemaPatcher {
+
+    public static final String VEHICLE_PRICING_PLAN_ID_SCHEMA_PATH = "$.properties.data.properties.vehicles.items.properties.pricing_plan_id";
+    public static final String BIKE_PRICING_PLAN_ID_SCHEMA_PATH = "$.properties.data.properties.bikes.items.properties.pricing_plan_id";
+
+    private final String fileName;
+
+    public NoInvalidReferenceToPricingPlansInVehicleStatus(String fileName) {
+        this.fileName = fileName;
+    }
+
+    /**
+     * Adds an enum to vehicle_status's pricing_plan_id schema with the plan ids from the system_pricing_plan feed
+     */
+    @Override
+    public DocumentContext addRule(DocumentContext rawSchemaDocumentContext, Map<String, JSONObject> feeds) {
+        JSONObject pricingPlansFeed = feeds.get("system_pricing_plans");
+
+        String requiredPath = VEHICLE_PRICING_PLAN_ID_SCHEMA_PATH;
+        // backwards compatibility
+        if (fileName.equals("free_bike_status")) {
+            requiredPath = BIKE_PRICING_PLAN_ID_SCHEMA_PATH;
+        }
+        JSONObject pricingPlanIdSchema = rawSchemaDocumentContext.read(requiredPath);
+
+        if (pricingPlansFeed != null) {
+            JSONArray pricingPlanIds = JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id");
+            pricingPlanIdSchema.put("enum", pricingPlanIds);
+        }
+
+        return rawSchemaDocumentContext
+                .set(requiredPath, pricingPlanIdSchema);
+    }
+}

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
@@ -18,7 +18,13 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
-import org.entur.gbfs.validation.validator.rules.*;
+import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
+import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
+import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
+import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
@@ -18,12 +18,7 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
-import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
-import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
-import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
-import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
+import org.entur.gbfs.validation.validator.rules.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -55,7 +50,8 @@ public class Version22 extends AbstractVersion {
             ),
             "free_bike_status", List.of(
                     new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
-                    new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status")
+                    new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status"),
+                    new NoInvalidReferenceToPricingPlansInVehicleStatus("free_bike_status")
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("free_bike_status")

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
@@ -18,13 +18,7 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
-import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
-import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
-import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
-import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
-import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
+import org.entur.gbfs.validation.validator.rules.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -59,7 +53,8 @@ public class Version23 extends AbstractVersion {
             ),
             "free_bike_status", List.of(
                     new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
-                    new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status")
+                    new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status"),
+                    new NoInvalidReferenceToPricingPlansInVehicleStatus("free_bike_status")
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("free_bike_status")

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
@@ -18,7 +18,14 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
-import org.entur.gbfs.validation.validator.rules.*;
+import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
+import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
+import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
+import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
@@ -18,13 +18,7 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
-import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
-import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
-import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
-import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
-import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
+import org.entur.gbfs.validation.validator.rules.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -58,7 +52,8 @@ public class Version30 extends AbstractVersion {
             ),
             "vehicle_status", List.of(
                     new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("vehicle_status"),
-                    new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("vehicle_status")
+                    new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("vehicle_status"),
+                    new NoInvalidReferenceToPricingPlansInVehicleStatus("vehicle_status")
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("vehicle_status")

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
@@ -18,7 +18,14 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
-import org.entur.gbfs.validation.validator.rules.*;
+import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
+import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
+import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
+import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/resources/fixtures/v2.2/free_bike_status.json
+++ b/src/test/resources/fixtures/v2.2/free_bike_status.json
@@ -21,7 +21,7 @@
         "vehicle_type_id":"def456",
         "current_range_meters":6543,
         "station_id":"86",
-        "pricing_plan_id":"plan3"
+        "pricing_plan_id":"plan2"
       }
     ]
   }

--- a/src/test/resources/fixtures/v2.3/free_bike_status.json
+++ b/src/test/resources/fixtures/v2.3/free_bike_status.json
@@ -25,7 +25,7 @@
         "vehicle_type_id":"def456",
         "current_range_meters":6543.0,
         "station_id":"86",
-        "pricing_plan_id":"plan3"
+        "pricing_plan_id":"bike_plan_1"
       }
     ]
   }

--- a/src/test/resources/fixtures/v3.0/vehicle_status.json
+++ b/src/test/resources/fixtures/v3.0/vehicle_status.json
@@ -25,7 +25,7 @@
         "vehicle_type_id":"def456",
         "current_range_meters":6543.0,
         "station_id":"86",
-        "pricing_plan_id":"plan3"
+        "pricing_plan_id":"bike_plan_1"
       },
       {
         "vehicle_id":"45bd3fb7-a2d5-4def-9de1-c645844ba962",
@@ -52,7 +52,7 @@
         "current_fuel_percent":0.7,
         "current_range_meters":6543.0,
         "station_id":"86",
-        "pricing_plan_id":"plan3",
+        "pricing_plan_id":"bike_plan_1",
         "home_station_id":"146",
         "vehicle_equipment":[
           "child_seat_a"


### PR DESCRIPTION
This PR adds a `NoInvalidReferenceToPricingPlansInVehicleStatus` for GBFS v2.2, v.2.3 and v3.0.

GBFS v2.1 introduced `[free_bike_status.pricing_plan_id](https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson)` but it's [schema](https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/free_bike_status.json) does not yet reflect it. 

This PR does not contain new test cases, but updates to existing ones, as these failed (correctly) with the currently used `pricing_plan_id`s.