### PR TITLE
feature: new rule to check that region_id in station_information exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The raw schema along with a map of the data feeds is passed to this method. The 
 
 List of additional rules:
 
+* `NoInvalidReferenceToPricingPlansInVehicleStatus`
 * `NoInvalidReferenceToPricingPlansInVehicleTypes`
+* `NoInvalidReferenceToRegionInStationInformation`
 * `NoInvalidReferenceToVehicleTypesInStationStatus`
 * `NoMissingVehicleTypesAvailableWhenVehicleTypesExists`
 * `NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist`

--- a/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
@@ -50,10 +50,10 @@ public class NoInvalidReferenceToRegionInStationInformation
     );
 
     if (systemRegionsFeed != null) {
-      JSONArray vehicleTypeIds = JsonPath
+      JSONArray regionIds = JsonPath
         .parse(systemRegionsFeed)
         .read("$.data.regions[*].region_id");
-      regionIdSchema.put("enum", vehicleTypeIds);
+      regionIdSchema.put("enum", regionIds);
     }
 
     return rawSchemaDocumentContext

--- a/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  *
+ *  *
+ *  *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  *  * You may not use this work except in compliance with the Licence.
+ *  *  * You may obtain a copy of the Licence at:
+ *  *  *
+ *  *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the Licence for the specific language governing permissions and
+ *  *  * limitations under the Licence.
+ *  *
+ *
+ */
+
+package org.entur.gbfs.validation.validator.rules;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Map;
+
+/**
+ * References to regions in station_information must exist in the system's system_regions file
+ */
+public class NoInvalidReferenceToRegionInStationInformation
+  implements CustomRuleSchemaPatcher {
+
+  public static final String REGION_IDS_SCHEMA_PATH =
+      "$.properties.data.properties.stations.items.properties.region_id";
+
+  /**
+   * Adds an enum to the region_id schema of stations.region_id with the region ids from system_regions.json
+   */
+  @Override
+  public DocumentContext addRule(
+    DocumentContext rawSchemaDocumentContext,
+    Map<String, JSONObject> feeds
+  ) {
+    JSONObject systemRegionsFeed = feeds.get("system_regions");
+    JSONObject regionIdSchema = rawSchemaDocumentContext.read(
+        REGION_IDS_SCHEMA_PATH
+    );
+
+    if (systemRegionsFeed != null) {
+      JSONArray vehicleTypeIds = JsonPath
+        .parse(systemRegionsFeed)
+        .read("$.data.regions[*].region_id");
+      regionIdSchema.put("enum", vehicleTypeIds);
+    }
+
+    return rawSchemaDocumentContext
+      .set(
+          REGION_IDS_SCHEMA_PATH,
+        regionIdSchema
+      );
+  }
+}

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version21.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version21.java
@@ -18,6 +18,7 @@
 
 package org.entur.gbfs.validation.validator.versions;
 
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
@@ -59,6 +60,9 @@ public class Version21 extends AbstractVersion {
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("free_bike_status")
+            ),
+            "station_information", List.of(
+                    new NoInvalidReferenceToRegionInStationInformation()
             )
     );
 

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
@@ -20,6 +20,7 @@ package org.entur.gbfs.validation.validator.versions;
 
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
@@ -61,6 +62,9 @@ public class Version22 extends AbstractVersion {
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("free_bike_status")
+            ),
+            "station_information", List.of(
+                    new NoInvalidReferenceToRegionInStationInformation()
             )
     );
 

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
@@ -21,6 +21,7 @@ package org.entur.gbfs.validation.validator.versions;
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
@@ -65,6 +66,9 @@ public class Version23 extends AbstractVersion {
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("free_bike_status")
+            ),
+            "station_information", List.of(
+                    new NoInvalidReferenceToRegionInStationInformation()
             )
     );
 

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
@@ -21,6 +21,7 @@ package org.entur.gbfs.validation.validator.versions;
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
@@ -64,6 +65,9 @@ public class Version30 extends AbstractVersion {
             ),
             "system_information", List.of(
                     new NoMissingStoreUriInSystemInformation("vehicle_status")
+            ),
+            "station_information", List.of(
+                    new NoInvalidReferenceToRegionInStationInformation()
             )
     );
 


### PR DESCRIPTION
This PR adds a new rule, which checks that `station.region_id` in `station_information` feed is defined in the `system_regions` feed.