### PR TITLE
feature: check vehicle_status for valid vehicle_type_id reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ List of additional rules:
 * `NoInvalidReferenceToRegionInStationInformation`
 * `NoInvalidReferenceToVehicleTypesInStationStatus`
 * `NoMissingVehicleTypesAvailableWhenVehicleTypesExists`
-* `NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist`
+* `NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist`
 * `NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles`
 * `NoMissingStoreUriInSystemInformation`
 

--- a/src/main/java/org/entur/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
@@ -53,9 +53,9 @@ public class NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist
 
         JSONObject vehicleItemsSchema = rawSchemaDocumentContext.read(requiredPath);
         if (vehicleTypesFeed != null) {
-            vehicleItemsSchema.put("required", new JSONArray().put("vehicle_type_id"));
+            vehicleItemsSchema.append("required", "vehicle_type_id");
             JSONArray vehicleTypeIds = JsonPath.parse(vehicleTypesFeed).read("$.data.vehicle_types[*].vehicle_type_id");
-            vehicleItemsSchema.put( "properties", new JSONObject().put("vehicle_type_id", new JSONObject().put("enum", vehicleTypeIds)));
+            vehicleItemsSchema.getJSONObject( "properties").getJSONObject("vehicle_type_id").put("enum", vehicleTypeIds);
         }
         return rawSchemaDocumentContext.set(requiredPath, vehicleItemsSchema);
     }

--- a/src/main/java/org/entur/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
@@ -21,6 +21,7 @@
 package org.entur.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -29,31 +30,33 @@ import java.util.Map;
 /**
  * Bikes / vehicles must refer to a vehicle type when vehicle_types exists
  */
-public class NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist implements CustomRuleSchemaPatcher {
+public class NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist implements CustomRuleSchemaPatcher {
 
     private final String fileName;
 
-    public NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist(String fileName) {
+    public NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist(String fileName) {
         this.fileName = fileName;
     }
 
-    public static final String BIKE_ITEMS_REQUIRED = "$.properties.data.properties.bikes.items.required";
-    public static final String VEHICLE_ITEMS_REQUIRED = "$.properties.data.properties.vehicles.items.required";
+    private static final String BIKE_ITEMS_SCHEMA_PATH = "$.properties.data.properties.bikes.items";
+    private static final String VEHICLE_ITEMS_SCHEMA_PATH = "$.properties.data.properties.vehicles.items";
     @Override
     public DocumentContext addRule(DocumentContext rawSchemaDocumentContext, Map<String, JSONObject> feeds) {
         JSONObject vehicleTypesFeed = feeds.get("vehicle_types");
 
-        String requiredPath = VEHICLE_ITEMS_REQUIRED;
+        String requiredPath = VEHICLE_ITEMS_SCHEMA_PATH;
 
         // backwards compatibility
         if (fileName.equals("free_bike_status")) {
-            requiredPath = BIKE_ITEMS_REQUIRED;
+            requiredPath = BIKE_ITEMS_SCHEMA_PATH;
         }
 
-        JSONArray vehicleItemsRequiredSchema = rawSchemaDocumentContext.read(requiredPath);
+        JSONObject vehicleItemsSchema = rawSchemaDocumentContext.read(requiredPath);
         if (vehicleTypesFeed != null) {
-            vehicleItemsRequiredSchema.put("vehicle_type_id");
+            vehicleItemsSchema.put("required", new JSONArray().put("vehicle_type_id"));
+            JSONArray vehicleTypeIds = JsonPath.parse(vehicleTypesFeed).read("$.data.vehicle_types[*].vehicle_type_id");
+            vehicleItemsSchema.put( "properties", new JSONObject().put("vehicle_type_id", new JSONObject().put("enum", vehicleTypeIds)));
         }
-        return rawSchemaDocumentContext.set(requiredPath, vehicleItemsRequiredSchema);
+        return rawSchemaDocumentContext.set(requiredPath, vehicleItemsSchema);
     }
 }

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version21.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version21.java
@@ -22,7 +22,7 @@ import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInSta
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
@@ -55,7 +55,7 @@ public class Version21 extends AbstractVersion {
                     new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
             ),
             "free_bike_status", List.of(
-                    new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
+                    new NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
                     new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status")
             ),
             "system_information", List.of(

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
@@ -24,7 +24,7 @@ import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInSta
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
 import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
 import java.util.Arrays;
@@ -56,7 +56,7 @@ public class Version22 extends AbstractVersion {
                     new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
             ),
             "free_bike_status", List.of(
-                    new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
+                    new NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
                     new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status"),
                     new NoInvalidReferenceToPricingPlansInVehicleStatus("free_bike_status")
             ),

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
@@ -25,7 +25,7 @@ import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInSta
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
 import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
 import java.util.Arrays;
@@ -60,7 +60,7 @@ public class Version23 extends AbstractVersion {
                     new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
             ),
             "free_bike_status", List.of(
-                    new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
+                    new NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("free_bike_status"),
                     new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("free_bike_status"),
                     new NoInvalidReferenceToPricingPlansInVehicleStatus("free_bike_status")
             ),

--- a/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
+++ b/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
@@ -25,7 +25,7 @@ import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInSta
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingStoreUriInSystemInformation;
-import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
+import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
 import org.entur.gbfs.validation.validator.rules.NoMissingVehicleTypesAvailableWhenVehicleTypesExists;
 
 import java.util.Arrays;
@@ -59,7 +59,7 @@ public class Version30 extends AbstractVersion {
                     new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
             ),
             "vehicle_status", List.of(
-                    new NoMissingVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("vehicle_status"),
+                    new NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist("vehicle_status"),
                     new NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles("vehicle_status"),
                     new NoInvalidReferenceToPricingPlansInVehicleStatus("vehicle_status")
             ),


### PR DESCRIPTION
This PR implements feature request #113: in case a feed provides `vehicle_types.json`, vehicle in `vehicle_status` / `free_bike_status` must not only declare a `vehicle_type_id`, but it must also be defined in `vehicle_types.json`.

Note: it should also be checked, that when `vehicle_type_id` is declared in `vehicle_status` / `free_bike_status`, `vehicle_types.json` must exist as well, which is not checked yet.