### PR TITLE
Use empty enums if no referenced regions/vehicle_types exist

### DIFF
--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleStatus.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleStatus.java
@@ -55,10 +55,10 @@ public class NoInvalidReferenceToPricingPlansInVehicleStatus implements CustomRu
         }
         JSONObject pricingPlanIdSchema = rawSchemaDocumentContext.read(requiredPath);
 
-        if (pricingPlansFeed != null) {
-            JSONArray pricingPlanIds = JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id");
-            pricingPlanIdSchema.put("enum", pricingPlanIds);
-        }
+        JSONArray pricingPlanIds = pricingPlansFeed != null
+            ? JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id")
+            : new JSONArray();
+        pricingPlanIdSchema.put("enum", pricingPlanIds);
 
         return rawSchemaDocumentContext
                 .set(requiredPath, pricingPlanIdSchema);

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleTypes.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleTypes.java
@@ -45,11 +45,11 @@ public class NoInvalidReferenceToPricingPlansInVehicleTypes implements CustomRul
         JSONObject defaultPricingPlanIdSchema = rawSchemaDocumentContext.read(DEFAULT_PRICING_PLAN_ID_SCHEMA_PATH);
         JSONObject pricingPlanIdsSchema = rawSchemaDocumentContext.read(PRICING_PLAN_IDS_SCHEMA_PATH);
 
-        if (pricingPlansFeed != null) {
-            JSONArray pricingPlanIds = JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id");
-            defaultPricingPlanIdSchema.put("enum", pricingPlanIds);
-            pricingPlanIdsSchema.put("enum", pricingPlanIds);
-        }
+        JSONArray pricingPlanIds = pricingPlansFeed != null
+            ? JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id")
+            : new JSONArray();
+        defaultPricingPlanIdSchema.put("enum", pricingPlanIds);
+        pricingPlanIdsSchema.put("enum", pricingPlanIds);
 
         return rawSchemaDocumentContext
                 .set(DEFAULT_PRICING_PLAN_ID_SCHEMA_PATH, defaultPricingPlanIdSchema)

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
@@ -49,12 +49,13 @@ public class NoInvalidReferenceToRegionInStationInformation
         REGION_IDS_SCHEMA_PATH
     );
 
-    if (systemRegionsFeed != null) {
-      JSONArray regionIds = JsonPath
-        .parse(systemRegionsFeed)
-        .read("$.data.regions[*].region_id");
-      regionIdSchema.put("enum", regionIds);
-    }
+    JSONArray regionIds = systemRegionsFeed != null
+        ? JsonPath
+            .parse(systemRegionsFeed)
+            .read("$.data.regions[*].region_id")
+        : new JSONArray();
+
+    regionIdSchema.put("enum", regionIds);
 
     return rawSchemaDocumentContext
       .set(

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToVehicleTypesInStationStatus.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToVehicleTypesInStationStatus.java
@@ -44,11 +44,12 @@ public class NoInvalidReferenceToVehicleTypesInStationStatus implements CustomRu
         JSONObject vehicleTypesAvailableVehicleTypeIdSchema = rawSchemaDocumentContext.read(VEHICLE_TYPES_AVAILABLE_VEHICLE_TYPE_ID_SCHEMA_PATH);
         JSONObject vehicleDocksAvailableVehiecleTypeIdSchema = rawSchemaDocumentContext.read(VEHICLE_DOCKS_AVAILABLE_VEHICLE_TYPE_IDS_SCHEMA_PATH);
 
-        if (vehicleTypesFeed != null) {
-            JSONArray vehicleTypeIds = JsonPath.parse(vehicleTypesFeed).read("$.data.vehicle_types[*].vehicle_type_id");
-            vehicleTypesAvailableVehicleTypeIdSchema.put("enum", vehicleTypeIds);
-            vehicleDocksAvailableVehiecleTypeIdSchema.put("enum", vehicleTypeIds);
-        }
+        // If no vehicle_types feed is defined, then any vehicle_type_id would be invalid
+        JSONArray vehicleTypeIds = vehicleTypesFeed != null
+            ? JsonPath.parse(vehicleTypesFeed).read("$.data.vehicle_types[*].vehicle_type_id")
+            : new JSONArray();
+        vehicleTypesAvailableVehicleTypeIdSchema.put("enum", vehicleTypeIds);
+        vehicleDocksAvailableVehiecleTypeIdSchema.put("enum", vehicleTypeIds);
 
         return rawSchemaDocumentContext
                 .set(VEHICLE_TYPES_AVAILABLE_VEHICLE_TYPE_ID_SCHEMA_PATH, vehicleTypesAvailableVehicleTypeIdSchema)

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
@@ -54,9 +54,11 @@ public class NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist
         JSONObject vehicleItemsSchema = rawSchemaDocumentContext.read(requiredPath);
         if (vehicleTypesFeed != null) {
             vehicleItemsSchema.append("required", "vehicle_type_id");
-            JSONArray vehicleTypeIds = JsonPath.parse(vehicleTypesFeed).read("$.data.vehicle_types[*].vehicle_type_id");
-            vehicleItemsSchema.getJSONObject( "properties").getJSONObject("vehicle_type_id").put("enum", vehicleTypeIds);
         }
+        JSONArray vehicleTypeIds = vehicleTypesFeed != null
+            ? JsonPath.parse(vehicleTypesFeed).read("$.data.vehicle_types[*].vehicle_type_id")
+            : new JSONArray();
+        vehicleItemsSchema.getJSONObject( "properties").getJSONObject("vehicle_type_id").put("enum", vehicleTypeIds);
         return rawSchemaDocumentContext.set(requiredPath, vehicleItemsSchema);
     }
 }

--- a/gbfs-validator-java/src/test/java/org/entur/gbfs/validation/validator/GbfsJsonValidatorTest.java
+++ b/gbfs-validator-java/src/test/java/org/entur/gbfs/validation/validator/GbfsJsonValidatorTest.java
@@ -206,7 +206,7 @@ class GbfsJsonValidatorTest {
         FileValidationResult result = validator.validateFile("free_bike_status", freeBikeStatus);
 
         Assertions.assertEquals("2.3", result.version());
-        Assertions.assertEquals(3, result.errorsCount());
+        Assertions.assertEquals(6, result.errorsCount());
     }
 
     @Test


### PR DESCRIPTION
This PR checks for empty enums for properties referencing system_regions or vehicle_types without their declaring feeds being defined.

Fixes  #120. 