### PR TITLE
fix: loader should assume v1.0 if version field is missing

### DIFF
--- a/gbfs-validator-java-loader/src/test/java/org/entur/gbfs/validator/loader/LoaderTest.java
+++ b/gbfs-validator-java-loader/src/test/java/org/entur/gbfs/validator/loader/LoaderTest.java
@@ -349,7 +349,7 @@ public class LoaderTest {
 
     LoadedFile discoveryFile = files
       .stream()
-      .filter(f -> f.fileName().equals("gbfs-v3.json"))
+      .filter(f -> f.fileName().equals("gbfs-v3"))
       .findFirst()
       .orElse(null);
     LoadedFile systemInfoFile = files

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/GbfsJsonValidator.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/GbfsJsonValidator.java
@@ -158,13 +158,10 @@ public class GbfsJsonValidator implements GbfsValidator {
   ) {
     ParsedFeedContainer gbfsContainer = parsedFeeds.get("gbfs");
     if (gbfsContainer != null && gbfsContainer.jsonObject() != null) {
-      try {
-        String versionStr = gbfsContainer.jsonObject().getString("version");
-        if (versionStr != null) {
-          return VersionFactory.createVersion(versionStr);
-        }
-      } catch (JSONException e) {
-        LOG.warn("Could not extract version from gbfs.json, using default.", e);
+      // Use optString to handle v1.0 feeds that don't have a version field
+      String versionStr = gbfsContainer.jsonObject().optString("version", null);
+      if (versionStr != null && !versionStr.isEmpty()) {
+        return VersionFactory.createVersion(versionStr);
       }
     }
     return VersionFactory.createVersion(GbfsJsonValidator.DEFAULT_VERSION);


### PR DESCRIPTION
This PR does the following:
* Similar to core validator, assume v1.0 in loader if version field is missing. The loader must determine the version in order to know how to parse the discovery file, so that it can fetch the remaining files.
* If for some reason it's not possible to parse the information from discovery file, we will nevertheless return it so it can be properly validated.

closes #179