### PR TITLE
fix: make schemaPath optional in open api spec

### DIFF
--- a/gbfs-validator-java-api/src/main/resources/public/openapi.yaml
+++ b/gbfs-validator-java-api/src/main/resources/public/openapi.yaml
@@ -104,7 +104,6 @@ components:
       required:
         - keyword
         - instancePath
-        - schemaPath
         - message
 
     SystemError:


### PR DESCRIPTION
Related to #184 

The validator engine is not always able to point to a specific location in the schema for a given error. This seems to be the case for allOf, anyOf and oneOf validations as well as enums. The reason presumably being that there are multiple locations to choose from.

This PR makes the field in the api response nullable, so that consumers can handle that it sometimes comes back as null.