### PR TITLE
feat: check station_information and station_status for corresponding station ids 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ List of additional rules:
 * `NoInvalidReferenceToPricingPlansInVehicleStatus`
 * `NoInvalidReferenceToPricingPlansInVehicleTypes`
 * `NoInvalidReferenceToRegionInStationInformation`
+* `NoInvalidReferenceToStation`
 * `NoInvalidReferenceToVehicleTypesInStationStatus`
 * `NoMissingVehicleTypesAvailableWhenVehicleTypesExists`
 * `NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist`

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToStation.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/rules/NoInvalidReferenceToStation.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  *
+ *  *
+ *  *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  *  * You may not use this work except in compliance with the Licence.
+ *  *  * You may obtain a copy of the Licence at:
+ *  *  *
+ *  *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the Licence for the specific language governing permissions and
+ *  *  * limitations under the Licence.
+ *  *
+ *
+ */
+
+package org.entur.gbfs.validation.validator.rules;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * References to stations in station_information must exist in station_status file and vice versa.
+ */
+public class NoInvalidReferenceToStation implements CustomRuleSchemaPatcher {
+
+  public static final String STATION_IDS_SCHEMA_PATH =
+    "$.properties.data.properties.stations.items.properties.station_id";
+
+  private final String stationReferenceFileName;
+
+  public NoInvalidReferenceToStation(String stationReferenceFileName) {
+    this.stationReferenceFileName = stationReferenceFileName;
+  }
+
+  /**
+   * Adds an enum to the station_id schema of stations.station_id with the station ids from station_status.json
+   */
+  @Override
+  public DocumentContext addRule(
+    DocumentContext rawSchemaDocumentContext,
+    Map<String, JSONObject> feeds
+  ) {
+    JSONObject stationReferenceFeed = feeds.get(stationReferenceFileName);
+
+    JSONObject stationIdSchema = rawSchemaDocumentContext.read(
+      STATION_IDS_SCHEMA_PATH
+    );
+
+    JSONArray stationIds = stationReferenceFeed != null
+      ? JsonPath
+        .parse(stationReferenceFeed)
+        .read("$.data.stations[*].station_id")
+      : new JSONArray();
+
+    stationIdSchema.put("enum", stationIds);
+
+    return rawSchemaDocumentContext.set(
+      STATION_IDS_SCHEMA_PATH,
+      stationIdSchema
+    );
+  }
+}

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version21.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version21.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToStation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
@@ -54,7 +55,8 @@ public class Version21 extends AbstractVersion {
       "station_status",
       List.of(
         new NoInvalidReferenceToVehicleTypesInStationStatus(),
-        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
+        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists(),
+        new NoInvalidReferenceToStation("station_information")
       ),
       "free_bike_status",
       List.of(
@@ -68,7 +70,10 @@ public class Version21 extends AbstractVersion {
       "system_information",
       List.of(new NoMissingStoreUriInSystemInformation("free_bike_status")),
       "station_information",
-      List.of(new NoInvalidReferenceToRegionInStationInformation())
+      List.of(
+        new NoInvalidReferenceToRegionInStationInformation(),
+        new NoInvalidReferenceToStation("station_status")
+      )
     );
 
   protected Version21() {

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version22.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToStation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
@@ -55,7 +56,8 @@ public class Version22 extends AbstractVersion {
       "station_status",
       List.of(
         new NoInvalidReferenceToVehicleTypesInStationStatus(),
-        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
+        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists(),
+        new NoInvalidReferenceToStation("station_information")
       ),
       "free_bike_status",
       List.of(
@@ -70,7 +72,10 @@ public class Version22 extends AbstractVersion {
       "system_information",
       List.of(new NoMissingStoreUriInSystemInformation("free_bike_status")),
       "station_information",
-      List.of(new NoInvalidReferenceToRegionInStationInformation())
+      List.of(
+        new NoInvalidReferenceToRegionInStationInformation(),
+        new NoInvalidReferenceToStation("station_status")
+      )
     );
 
   protected Version22() {

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version23.java
@@ -25,6 +25,7 @@ import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToStation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
@@ -58,7 +59,8 @@ public class Version23 extends AbstractVersion {
       "station_status",
       List.of(
         new NoInvalidReferenceToVehicleTypesInStationStatus(),
-        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
+        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists(),
+        new NoInvalidReferenceToStation("station_information")
       ),
       "free_bike_status",
       List.of(
@@ -73,7 +75,10 @@ public class Version23 extends AbstractVersion {
       "system_information",
       List.of(new NoMissingStoreUriInSystemInformation("free_bike_status")),
       "station_information",
-      List.of(new NoInvalidReferenceToRegionInStationInformation())
+      List.of(
+        new NoInvalidReferenceToRegionInStationInformation(),
+        new NoInvalidReferenceToStation("station_status")
+      )
     );
 
   protected Version23() {

--- a/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
+++ b/gbfs-validator-java/src/main/java/org/entur/gbfs/validation/validator/versions/Version30.java
@@ -25,6 +25,7 @@ import org.entur.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleStatus;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToPricingPlansInVehicleTypes;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToRegionInStationInformation;
+import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToStation;
 import org.entur.gbfs.validation.validator.rules.NoInvalidReferenceToVehicleTypesInStationStatus;
 import org.entur.gbfs.validation.validator.rules.NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles;
 import org.entur.gbfs.validation.validator.rules.NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist;
@@ -57,7 +58,8 @@ public class Version30 extends AbstractVersion {
       "station_status",
       List.of(
         new NoInvalidReferenceToVehicleTypesInStationStatus(),
-        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists()
+        new NoMissingVehicleTypesAvailableWhenVehicleTypesExists(),
+        new NoInvalidReferenceToStation("station_information")
       ),
       "vehicle_status",
       List.of(
@@ -72,7 +74,10 @@ public class Version30 extends AbstractVersion {
       "system_information",
       List.of(new NoMissingStoreUriInSystemInformation("vehicle_status")),
       "station_information",
-      List.of(new NoInvalidReferenceToRegionInStationInformation())
+      List.of(
+        new NoInvalidReferenceToRegionInStationInformation(),
+        new NoInvalidReferenceToStation("station_status")
+      )
     );
 
   protected Version30() {

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.1/station_information.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.1/station_information.json
@@ -5,13 +5,23 @@
   "data": {
     "stations": [
       {
-        "station_id": "pga",
+        "station_id": "station1",
         "name": "Parking garage A",
         "lat": 12.345678,
         "lon": 45.678901,
         "vehicle_type_capacity": {
           "abc123": 7,
           "def456": 9
+        }
+      },
+      {
+        "station_id": "station2",
+        "name": "SE Belmont & SE 10th",
+        "lat": 45.516445,
+        "lon": -122.655775,
+        "vehicle_type_capacity": {
+          "abc123": 0,
+          "def456": 0
         }
       }
     ]

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.1/station_information_virtual.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.1/station_information_virtual.json
@@ -5,7 +5,7 @@
   "data":{
     "stations":[
       {
-        "station_id":"station12",
+        "station_id":"station2",
         "station_name":"SE Belmont & SE 10 th ",
         "is_valet_station":false,
         "is_virtual_station":true,

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.1/station_status.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.1/station_status.json
@@ -5,7 +5,7 @@
   "data": {
     "stations": [
       {
-        "station_id": "station 1",
+        "station_id": "station1",
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,
@@ -27,7 +27,7 @@
           "count": 0
         }]
       }, {
-        "station_id": "station 2",
+        "station_id": "station2",
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.2/station_information.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.2/station_information.json
@@ -5,13 +5,23 @@
   "data": {
     "stations": [
       {
-        "station_id": "pga",
+        "station_id": "station1",
         "name": "Parking garage A",
         "lat": 12.345678,
         "lon": 45.678901,
         "vehicle_type_capacity": {
           "abc123": 7,
           "def456": 9
+        }
+      },
+      {
+        "station_id": "station2",
+        "name": "SE Belmont & SE 10th",
+        "lat": 45.516445,
+        "lon": -122.655775,
+        "vehicle_type_capacity": {
+          "abc123": 0,
+          "def456": 0
         }
       }
     ]

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.2/station_information_virtual.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.2/station_information_virtual.json
@@ -5,7 +5,7 @@
   "data":{
     "stations":[
       {
-        "station_id":"station12",
+        "station_id":"station2",
         "station_name":"SE Belmont & SE 10 th ",
         "is_valet_station":false,
         "is_virtual_station":true,

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.2/station_status.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.2/station_status.json
@@ -5,7 +5,7 @@
   "data": {
     "stations": [
       {
-        "station_id": "station 1",
+        "station_id": "station1",
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,
@@ -27,7 +27,7 @@
           "count": 0
         }]
       }, {
-        "station_id": "station 2",
+        "station_id": "station2",
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.3/station_information.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.3/station_information.json
@@ -5,7 +5,7 @@
   "data": {
     "stations": [
       {
-        "station_id": "pga",
+        "station_id": "station1",
         "name": "Parking garage A",
         "lat": 12.345678,
         "lon": 45.678901,
@@ -16,6 +16,16 @@
         "vehicle_type_capacity": {
           "abc123": 7,
           "def456": 9
+        }
+      },
+      {
+        "station_id": "station2",
+        "name": "SE Belmont & SE 10th",
+        "lat": 45.516445,
+        "lon": -122.655775,
+        "vehicle_type_capacity": {
+          "abc123": 0,
+          "def456": 0
         }
       }
     ]

--- a/gbfs-validator-java/src/test/resources/fixtures/v2.3/station_information_virtual.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v2.3/station_information_virtual.json
@@ -5,7 +5,7 @@
   "data": {
     "stations": [
       {
-        "station_id": "station12",
+        "station_id": "station2",
         "name": "SE Belmont & SE 10 th",
         "lat": 45.516445,
         "lon": -122.655775,

--- a/gbfs-validator-java/src/test/resources/fixtures/v3.0/station_information.json
+++ b/gbfs-validator-java/src/test/resources/fixtures/v3.0/station_information.json
@@ -5,7 +5,7 @@
   "data": {
     "stations": [
       {
-        "station_id": "pga",
+        "station_id": "station1",
         "name": [
           {
             "text": "Parking garage A",
@@ -31,7 +31,7 @@
         ]
       },
       {
-        "station_id": "station12",
+        "station_id": "station2",
         "name": [
           {
             "text": "SE Belmont & SE 10th",


### PR DESCRIPTION
This PR adds a "foreign key" reference check for `station_information`' and `station_status`' `station_id`s.

Besides the addition of rule `NoInvalidReferenceToStation` it fixes test fixtures which had inconsistent `station_id`s in their `station_information` and `station_status` feeds.

## Motivation
The GBFS spec for versions greater or equal to v2.1 says:

> Any station that is represented in station_status.json MUST have a corresponding entry in station_information.json.
and
> Any station that is represented in station_information.json MUST have a corresponding entry in station_status.json.

Note: This PR includes this check for v2.2, v.2.3 and v3.0. If you agree with the implementation, I'd add it for v2.1 as well. v2.0 had this requirement not yet clearly spelled out, so I'd not add the validation for <=2.0.