### PR TITLE
fix: stop mutating JsonPath JVM-global defaults

### DIFF
--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/SchemaJsonPath.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/SchemaJsonPath.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.mobilitydata.gbfs.validation.validator;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
+
+/**
+ * Thin facade over {@link JsonPath} that always uses {@link JsonOrgJsonProvider}
+ * and {@link JsonOrgMappingProvider}. All schema-patching code in this library
+ * operates on {@code org.json.JSONObject} / {@code JSONArray}, which the default
+ * JsonPath provider does not recognise.
+ *
+ * <p>Use {@link #parse(Object)} instead of {@code JsonPath.parse(...)} so that
+ * we never depend on {@link Configuration#setDefaults(Configuration.Defaults)} —
+ * mutating that JVM-wide default would silently break any other JsonPath user
+ * in the same process (e.g. Spring's GraphQL test tooling).
+ */
+public final class SchemaJsonPath {
+
+  private static final Configuration CONFIGURATION = Configuration
+    .builder()
+    .jsonProvider(new JsonOrgJsonProvider())
+    .mappingProvider(new JsonOrgMappingProvider())
+    .build();
+
+  private SchemaJsonPath() {}
+
+  /**
+   * Parse an {@code org.json.JSONObject}, {@code JSONArray} or JSON string into a
+   * {@link DocumentContext} configured to read and write {@code org.json} types.
+   */
+  public static DocumentContext parse(Object json) {
+    return JsonPath.using(CONFIGURATION).parse(json);
+  }
+}

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleStatus.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleStatus.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * A vehicle's pricing_plan_id must exist in the system's system_pricing_plan file
@@ -63,7 +63,7 @@ public class NoInvalidReferenceToPricingPlansInVehicleStatus
     );
 
     JSONArray pricingPlanIds = pricingPlansFeed != null
-      ? JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id")
+      ? SchemaJsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id")
       : new JSONArray();
     pricingPlanIdSchema.put("enum", pricingPlanIds);
 

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleTypes.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToPricingPlansInVehicleTypes.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * A vehicle's default_pricing_plan_id, and all pricing_plan_ids must exist in the system's system_pricing_plan file
@@ -54,7 +54,7 @@ public class NoInvalidReferenceToPricingPlansInVehicleTypes
     );
 
     JSONArray pricingPlanIds = pricingPlansFeed != null
-      ? JsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id")
+      ? SchemaJsonPath.parse(pricingPlansFeed).read("$.data.plans[*].plan_id")
       : new JSONArray();
     defaultPricingPlanIdSchema.put("enum", pricingPlanIds);
     pricingPlanIdsSchema.put("enum", pricingPlanIds);

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToRegionInStationInformation.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * References to regions in station_information must exist in the system's system_regions file
@@ -49,7 +49,9 @@ public class NoInvalidReferenceToRegionInStationInformation
     );
 
     JSONArray regionIds = systemRegionsFeed != null
-      ? JsonPath.parse(systemRegionsFeed).read("$.data.regions[*].region_id")
+      ? SchemaJsonPath
+        .parse(systemRegionsFeed)
+        .read("$.data.regions[*].region_id")
       : new JSONArray();
 
     regionIdSchema.put("enum", regionIds);

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToStation.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToStation.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * References to stations in station_information must exist in station_status file and vice versa.
@@ -55,7 +55,7 @@ public class NoInvalidReferenceToStation implements CustomRuleSchemaPatcher {
     );
 
     JSONArray stationIds = stationReferenceFeed != null
-      ? JsonPath
+      ? SchemaJsonPath
         .parse(stationReferenceFeed)
         .read("$.data.stations[*].station_id")
       : new JSONArray();

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToVehicleTypesInStationStatus.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoInvalidReferenceToVehicleTypesInStationStatus.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * References to vehicle types in station_status must exist in the system's vehicle_types file
@@ -57,7 +57,7 @@ public class NoInvalidReferenceToVehicleTypesInStationStatus
 
     // If no vehicle_types feed is defined, then any vehicle_type_id would be invalid
     JSONArray vehicleTypeIds = vehicleTypesFeed != null
-      ? JsonPath
+      ? SchemaJsonPath
         .parse(vehicleTypesFeed)
         .read("$.data.vehicle_types[*].vehicle_type_id")
       : new JSONArray();

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles.java
@@ -24,11 +24,11 @@ import static com.jayway.jsonpath.Criteria.where;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.Filter;
-import com.jayway.jsonpath.JsonPath;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * It is required to provide the current_range_meters property in vehicle_status for motorized vehicles
@@ -64,7 +64,7 @@ public class NoMissingCurrentRangeMetersInVehicleStatusForMotorizedVehicles
 
     if (vehicleTypesFeed != null) {
       motorizedVehicleTypeIds =
-        JsonPath
+        SchemaJsonPath
           .parse(vehicleTypesFeed)
           .read(
             "$.data.vehicle_types[?].vehicle_type_id",

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * Bikes / vehicles must refer to a vehicle type when vehicle_types exists
@@ -64,7 +64,7 @@ public class NoMissingOrInvalidVehicleTypeIdInVehicleStatusWhenVehicleTypesExist
       vehicleItemsSchema.append("required", "vehicle_type_id");
     }
     JSONArray vehicleTypeIds = vehicleTypesFeed != null
-      ? JsonPath
+      ? SchemaJsonPath
         .parse(vehicleTypesFeed)
         .read("$.data.vehicle_types[*].vehicle_type_id")
       : new JSONArray();

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoMissingStoreUriInSystemInformation.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/rules/NoMissingStoreUriInSystemInformation.java
@@ -21,10 +21,10 @@
 package org.mobilitydata.gbfs.validation.validator.rules;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 
 /**
  * It is required to provide ios and android store uris in system_information if vehicle_status
@@ -61,7 +61,7 @@ public class NoMissingStoreUriInSystemInformation
 
       if (
         !(
-          (JSONArray) JsonPath
+          (JSONArray) SchemaJsonPath
             .parse(vehicleStatusFeed)
             .read("$.data." + vehiclesKey + "[:1].rental_uris.ios")
         ).isEmpty()
@@ -71,7 +71,7 @@ public class NoMissingStoreUriInSystemInformation
 
       if (
         !(
-          (JSONArray) JsonPath
+          (JSONArray) SchemaJsonPath
             .parse(vehicleStatusFeed)
             .read("$.data." + vehiclesKey + "[:1].rental_uris.android")
         ).isEmpty()
@@ -85,7 +85,7 @@ public class NoMissingStoreUriInSystemInformation
     if (stationInformationFeed != null) {
       if (
         !(
-          (JSONArray) JsonPath
+          (JSONArray) SchemaJsonPath
             .parse(stationInformationFeed)
             .read("$.data.stations[:1].rental_uris.ios")
         ).isEmpty()
@@ -95,7 +95,7 @@ public class NoMissingStoreUriInSystemInformation
 
       if (
         !(
-          (JSONArray) JsonPath
+          (JSONArray) SchemaJsonPath
             .parse(stationInformationFeed)
             .read("$.data.stations[:1].rental_uris.android")
         ).isEmpty()

--- a/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/versions/AbstractVersion.java
+++ b/gbfs-validator-java/src/main/java/org/mobilitydata/gbfs/validation/validator/versions/AbstractVersion.java
@@ -18,20 +18,11 @@
 
 package org.mobilitydata.gbfs.validation.validator.versions;
 
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonProvider;
-import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
-import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
@@ -39,6 +30,7 @@ import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.mobilitydata.gbfs.validation.validator.FileValidator;
+import org.mobilitydata.gbfs.validation.validator.SchemaJsonPath;
 import org.mobilitydata.gbfs.validation.validator.URIFormatValidator;
 import org.mobilitydata.gbfs.validation.validator.rules.CustomRuleSchemaPatcher;
 import org.slf4j.Logger;
@@ -53,30 +45,6 @@ public abstract class AbstractVersion implements Version {
   private final List<String> feeds;
   private final Map<String, JSONObject> schemas = new ConcurrentHashMap<>();
   private final Map<String, List<CustomRuleSchemaPatcher>> customRules;
-
-  static {
-    Configuration.setDefaults(
-      new Configuration.Defaults() {
-        final JsonProvider jsonProvider = new JsonOrgJsonProvider();
-        final MappingProvider mappingProvider = new JsonOrgMappingProvider();
-
-        @Override
-        public JsonProvider jsonProvider() {
-          return jsonProvider;
-        }
-
-        @Override
-        public Set<Option> options() {
-          return EnumSet.noneOf(Option.class);
-        }
-
-        @Override
-        public MappingProvider mappingProvider() {
-          return mappingProvider;
-        }
-      }
-    );
-  }
 
   protected AbstractVersion(
     String versionString,
@@ -157,7 +125,7 @@ public abstract class AbstractVersion implements Version {
   ) {
     // Must make a copy of the schema, otherwise it will be mutated by json-path
     return patcher
-      .addRule(JsonPath.parse(new JSONObject(schema.toMap())), feedMap)
+      .addRule(SchemaJsonPath.parse(new JSONObject(schema.toMap())), feedMap)
       .json();
   }
 


### PR DESCRIPTION
AbstractVersion's static initializer called Configuration.setDefaults(...) to install JsonOrgJsonProvider as the JVM-wide JsonPath default. Once that class loaded, every other JsonPath user in the same process was forced onto the org.json provider — which only recognises org.json.JSONObject as a map. A consumer using JsonPath against Jackson-parsed maps (e.g. Spring's WebGraphQlTester feeding LinkedHashMap responses to JsonPath) would then fail with PathNotFoundException whenever validator classes happened to load before that consumer first evaluated a path. Class-load order makes the bug intermittent: it surfaces in some test environments but not others.

Replace the global mutation with a SchemaJsonPath facade that exposes a single static parse(Object) returning a DocumentContext bound to a private JsonOrg-configured Configuration. All JsonPath.parse(jsonObject) call sites in AbstractVersion and the rule patchers now route through the facade, so adding a new schema-patching rule cannot accidentally fall back to the default provider.