### PR TITLE
fix: use official gtfs-validator v7.1.0 release tag instead of USED_BY_GBFS_VALIDATOR_JAVA

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -53,8 +53,8 @@ jobs:
             ${{ runner.os }}-
       - name: Load secrets from 1Password
         if: env.HAS_1PASSWORD == 'true'
-        # Pinned to a specific tag for supply-chain safety. Update the tag in gtfs-validator if the action changes.
-        uses: MobilityData/gtfs-validator/.github/actions/extract-1password-secret@USED_BY_GBFS_VALIDATOR_JAVA # 7bf2832
+        # Uses the official gtfs-validator release tag. Update to a newer release tag when the action changes.
+        uses: MobilityData/gtfs-validator/.github/actions/extract-1password-secret@v7.1.0
         with:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           VARIABLES_TO_EXTRACT: 'MAVEN_GPG_PASSPHRASE, MAVEN_GPG_PRIVATE_KEY, MAVEN_CENTRAL_PORTAL_TOKEN_USERNAME, MAVEN_CENTRAL_PORTAL_TOKEN_PASSWORD'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
             ${{ runner.os }}-
       - name: Load secrets from 1Password
         if: env.HAS_1PASSWORD == 'true'
-        # Pinned to a specific tag for supply-chain safety. Update the tag in gtfs-validator if the action changes.
-        uses: MobilityData/gtfs-validator/.github/actions/extract-1password-secret@USED_BY_GBFS_VALIDATOR_JAVA # 7bf2832
+        # Uses the official gtfs-validator release tag. Update to a newer release tag when the action changes.
+        uses: MobilityData/gtfs-validator/.github/actions/extract-1password-secret@v7.1.0
         with:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           VARIABLES_TO_EXTRACT: 'MAVEN_GPG_PASSPHRASE, MAVEN_GPG_PRIVATE_KEY, MAVEN_CENTRAL_PORTAL_TOKEN_USERNAME, MAVEN_CENTRAL_PORTAL_TOKEN_PASSWORD'


### PR DESCRIPTION
## Summary

The `extract-1password-secret` action from `MobilityData/gtfs-validator` was referenced using a custom tag `USED_BY_GBFS_VALIDATOR_JAVA` that was created specifically for this project. This PR replaces that tag with the official `v7.1.0` release tag which already exists in the gtfs-validator repository.

## Changes
- `.github/workflows/deploy-snapshot.yml`: Replace `@USED_BY_GBFS_VALIDATOR_JAVA` with `@v7.1.0`
- `.github/workflows/release.yml`: Replace `@USED_BY_GBFS_VALIDATOR_JAVA` with `@v7.1.0`
- Updated the comment above the action usage to reflect the use of an official release tag

## Why
Using an official release tag is better practice than a custom tag, as it ties the reference to a well-defined, versioned release of the gtfs-validator project.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>